### PR TITLE
feat(sonarcloud): Use Sonarcloud with Jest coverage reporter export. …

### DIFF
--- a/packages/webapp/README.md
+++ b/packages/webapp/README.md
@@ -31,6 +31,28 @@ Snapshots are to be checked in and are found in
 
 > To run from root refer the [Readme](../../README.md)
 
+#### Static Testing
+
+There is support with [SonarCloud](https://sonarcloud.io/) for static analysis. We can run this with [SonarScanner Docker](https://github.com/SonarSource/sonar-scanner-cli-docker)
+
+In order to run, the export the followings environment variables for the SonarCloud Project:
+
+```bash
+export SONAR_TOKEN=
+export SONAR_PROJECT_NAME=
+export SONAR_PROJECT_KEY=
+export SONAR_ORGANIZATION=
+```
+
+To find this, please ensure that you sign up with GitHub to [Sonarcloud](https://sonarcloud.io).
+
+First generate the code coverage results, then run the SonarCloud scanner and push up the results:
+
+```bash
+yarn test
+docker run -e SONAR_HOST_URL=https://sonarcloud.io -e SONAR_TOKEN=$SONAR_TOKEN -e SONAR_PROJECT_KEY=$SONAR_PROJECT_KEY -e SONAR_PROJECT_KEY=$SONAR_PROJECT_KEY -e SONAR_ORGANIZATION=$SONAR_ORGANIZATION -it -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli
+```
+
 ## To build and run using Docker
 
 In order to be able to build and run the webapp template, across environments

--- a/packages/webapp/jest.config.js
+++ b/packages/webapp/jest.config.js
@@ -2,8 +2,10 @@ module.exports = {
   testPathIgnorePatterns: [
     '<rootDir>/.next/',
     '<rootDir>/node_modules/',
-    '<rootDir>/__tests__/coverage/',
+    '<rootDir>/coverage/',
   ],
+  testResultsProcessor: 'jest-sonar-reporter',
+  coverageReporters: ['lcov'],
   collectCoverage: true,
   collectCoverageFrom: [
     '**/*.{js,jsx,ts,tsx}',
@@ -13,7 +15,7 @@ module.exports = {
     '!**/.next/**',
     '!**/next-env.d.ts',
   ],
-  coverageDirectory: '<rootDir>./__tests__/coverage/',
+  coverageDirectory: '<rootDir>./coverage/',
   coverageThreshold: {
     global: {
       statements: 100,

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -24,6 +24,7 @@
     "babel-jest": "^24.9.0",
     "isomorphic-unfetch": "^3.0.0",
     "jest": "^24.9.0",
+    "jest-sonar-reporter": "^2.0.0",
     "ts-jest": "^24.3.0",
     "typescript": "^3.7.4"
   },

--- a/packages/webapp/pages/index.tsx
+++ b/packages/webapp/pages/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from 'react'
 
-const Home = () => <div>Welcome to Stacks-react app!</div>;
-export default Home;
+const Home = () => <div>Welcome to Stacks-react app!</div>
+export default Home

--- a/yarn.lock
+++ b/yarn.lock
@@ -6488,6 +6488,13 @@ jest-snapshot@^24.9.0:
     pretty-format "^24.9.0"
     semver "^6.2.0"
 
+jest-sonar-reporter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-sonar-reporter/-/jest-sonar-reporter-2.0.0.tgz#faa54a7d2af7198767ee246a82b78c576789cf08"
+  integrity sha512-ZervDCgEX5gdUbdtWsjdipLN3bKJwpxbvhkYNXTAYvAckCihobSLr9OT/IuyNIRT1EZMDDwR6DroWtrq+IL64w==
+  dependencies:
+    xml "^1.0.1"
+
 jest-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"
@@ -11162,6 +11169,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
#### 📲 What

Uses the sonarcloud reporter with Jest to be able to scan the code, and pull in the coverage reports. Only using `docker run` at current. 

**TODO: Needs to be put in docker file, after the tests are run.**

Important to note that the `lcov.info` file contains a relative path. For this to work, the tests need to run in the same docker container so that the scanner can reference the correct files.

Also note that you must sign up for a Sonarcloud account with Github credentials to produce a token and to be able to access the Sonarcloud Org and Projects.

**TODO: Pipeline integration with SonarCloud with Github**

#### 🤔 Why
		
We want to ensure that we can integrate with SonarCloud without it being tied to a pipeline, and able to be run on any machine with Docker.
		
#### 🛠 How
		
See the README. To view the latest results ass produced from local: https://sonarcloud.io/dashboard?id=stacks-webapp-template

#### 👀 Evidence
<img width="1618" alt="Screenshot 2020-01-10 at 14 47 03" src="https://user-images.githubusercontent.com/47354603/72164814-499c3c00-33be-11ea-8242-e75412ce6f88.png">
 
#### 🕵️ How to test
See the README for instructions.

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
