### PR TITLE
feat: start pact-stub server from the pact files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -89,7 +89,8 @@
         "PORT": "3000",
         "APP_BASE_PATH": "/foo",
         "APP_BASE_URL": "http://localhost",
-        "MENU_API_URL": "http://dev.amidostacks.com/api/menu"
+        "MENU_API_URL": "http://dev.amidostacks.com/api/menu",
+        "PACT_BROKER": "https://amido-stacks.pact.dius.com.au"
       },
       "args": [
         // "--project tsconfig.server.json"

--- a/packages/template-cli/templates/src/ssr/README.md
+++ b/packages/template-cli/templates/src/ssr/README.md
@@ -126,3 +126,31 @@ PACT_BEARER_TOKEN=
 # Publish the pacts to the configured broker
 npm run test:pact-publish
 ```
+
+#### Pact Stub Service
+Pact contracts are easily turned into locally running API stubs. They are great for using as a simple service to run integration tests against, whether with Jest, or with Cypress. This ensures that you can test your application without hitting the actual endpoint, and ensures the same response everytime, without duplicating mock definitions.
+
+If gives the consumer confidence that if the contract tests are passing with the provider, then the mocks should suffice to test parts of their application against.
+
+No more updating stub responses that go out of date. Hooray!
+
+The Pact files (.json) are generated when the Pact tests are run (`npm run tests:pact`), and are published to the broker on succeeding. In order to get the latest pact file to generate the stub service from, you can either:
+
+1. Run the tests, which will output the Pact .json files to [__tests__/pacts](./__tests__/pacts)
+2. Pull down the latest passing contracts from the broker (`https://PACT_BROKER/pacts/provider/PROVIDER/consumer/CONSUMER/latest`)
+
+Once the files are sourced, it's as simple as starting the stub service either from the npm script in CI, or by calling the [pactStubServer.ts](./pact/packStubServer.ts) from your test.
+
+```bash
+# To start the Pact stub server
+npm run test:pact-start-stub
+```
+
+To test the server:
+
+```bash
+# To test that the service is running and returning expected responses:
+curl -v localhost:8389/v1/menu/7f993e28-b9b1-4ea7-830b-b30f9758db68 -H "Accept: application/json"
+```
+
+Please remember to always stop your server once done testing.

--- a/packages/template-cli/templates/src/ssr/__tests__/pacts/genericmenuconsumer-menuapi.json
+++ b/packages/template-cli/templates/src/ssr/__tests__/pacts/genericmenuconsumer-menuapi.json
@@ -1,0 +1,71 @@
+{
+  "consumer": {
+    "name": "GenericMenuConsumer"
+  },
+  "provider": {
+    "name": "MenuAPI"
+  },
+  "interactions": [
+    {
+      "description": "A request for a menu by ID",
+      "providerState": "An existing menu",
+      "request": {
+        "method": "GET",
+        "path": "/v1/menu/7f993e28-b9b1-4ea7-830b-b30f9758db68",
+        "headers": {
+          "Accept": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+          "name": "Burger Menu",
+          "description": "Cheese burger",
+          "enabled": true
+        }
+      },
+      "metadata": null
+    },
+    {
+      "description": "A request for all menus",
+      "providerState": "An existing menu",
+      "request": {
+        "method": "GET",
+        "path": "/v1/menu",
+        "query": "pageSize=1&pageNumber=1",
+        "headers": {
+          "Accept": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "pageSize": 1,
+          "pageNumber": 1,
+          "results": [
+            {
+              "id": "1234",
+              "restaurantId": "1234",
+              "name": "Breakfast Menu",
+              "description": "Eggs, Bread, Coffee and more",
+              "enabled": true
+            }
+          ]
+        }
+      },
+      "metadata": null
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}

--- a/packages/template-cli/templates/src/ssr/package.json
+++ b/packages/template-cli/templates/src/ssr/package.json
@@ -8,7 +8,8 @@
     "lint": "node_modules/.bin/eslint",
     "validate": "echo 'This should be a validate linting task.'",
     "test:pact": "node_modules/.bin/jest --c jest-pact.config.json --rootDir . --runInBand ",
-    "test:pact-publish": "tsc ./pact/pactPublish.ts && node ./pact/pactPublish.js",
+    "test:pact-publish": "node_modules/.bin/tsc ./pact/pactPublish.ts && node ./pact/pactPublish.js",
+    "test:pact-start-stub": "node_modules/.bin/tsc pact/packStubServer.ts && node pact/packStubServer.js",
     "clean:tree": "git clean -idx"
   },
   "engines": {

--- a/packages/template-cli/templates/src/ssr/pact/packStubServer.ts
+++ b/packages/template-cli/templates/src/ssr/pact/packStubServer.ts
@@ -1,0 +1,9 @@
+import { Stub } from '@pact-foundation/pact-node'
+import { provider } from './pactSetup'
+
+const port = 8389
+
+export const server = new Stub({
+    port: port,
+    pactUrls: [`${provider.opts.dir}`] //Local .json Pact files must be retrieved from the broker OR generated through the Pact tests first
+}).start();


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

[AB#694](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/694) - mocking the API service using Pact.

#### 🤔 Why
		
So we aren't deuplicating mocks. Can be used for functional or integration tests.
		
#### 🛠 How
		
Using pact-stub-service

#### 👀 Evidence
```
$ curl -v localhost:8389/v1/menu/7f993e28-b9b1-4ea7-830b-b30f9758db68 -H "Accept: application/json"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8389 (#0)
> GET /v1/menu/7f993e28-b9b1-4ea7-830b-b30f9758db68 HTTP/1.1
> Host: localhost:8389
> User-Agent: curl/7.54.0
> Accept: application/json
> 
< HTTP/1.1 200 OK 
< Content-Type: application/json; charset=utf-8
< Server: WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13) OpenSSL/1.0.2d
< Date: Wed, 12 Feb 2020 18:20:52 GMT
< Content-Length: 111
< Connection: Keep-Alive
< 
* Connection #0 to host localhost left intact
{"id":"d290f1ee-6c54-4b01-90e6-d701748f0851","name":"Burger Menu","description":"Cheese burger","enabled":true}
```		
		 
#### 🕵️ How to test

`npm run test:pact`
`nom run test:pact-start-stub`

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
