### PR TITLE
fix: set tracking right

### DIFF
--- a/build/azDevOps/azure/templates/steps/publish-packages-lerna.yml
+++ b/build/azDevOps/azure/templates/steps/publish-packages-lerna.yml
@@ -22,9 +22,10 @@ steps:
       git remote -v
       git fetch
       SHA=$(Build.SourceVersion)
-      git checkout -b release-${SHA:0:7} master
-      git reset --mixed $(Build.SourceVersion)
+      git checkout -b release-${SHA:0:7}
+      git reset --mixed $SHA
       git update-index --assume-unchanged .npmrc
+      git push -u origin release-${SHA:0:7}
     displayName: Create release branch for $(Build.SourceVersion)
 
   # Ensure Node.js 12 is active


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Set the tracking right. It was failing:

`fatal: 'master' is not a commit and a branch 'release-84c8cf3' cannot be created from it`

<!--
If you have access, to ink to the Azure Devops Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
 To ensure lerna can release from a branch.
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
