### PR TITLE
fix: allow publishing from release branch

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
       "sort": false
     },
     "publish": {
-      "allowBranch": ["master"]
+      "allowBranch": ["master", "release-*"]
     },
     "version": {
       "message": "chore(release): publish"


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Allow publishing from created release branch.

<!--
If you have accesss, to ink to the Azure Devops Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
`lerna ERR! ENOTALLOWED Branch 'release-14d44ee' is restricted from versioning due to allowBranch config`
		
#### 🛠 How
		
allowBranch to be any master or release-*

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
