### PR TITLE
fix: title element overwritten on tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ yarn.lock
 
 # APPLITOOLS
 .applitools/
+
+# TESTCAFE
+**/screenshots/

--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
@@ -194,4 +194,4 @@ stages:
                             APP_BASE_PATH: "/web/stacks"
                             NODE_ENV: production
                           workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)/test/testcafe
-                          testcafe_browser_list: "chrome,firefox,ie"
+                          testcafe_browser_list: "chrome,firefox"

--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
@@ -193,5 +193,5 @@ stages:
                             APP_BASE_PATH: "/web/stacks"
                             NODE_ENV: production
                           workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)/test/testcafe
-                          testcafe_browser_list: "chrome,firefox,ie"
+                          testcafe_browser_list: "chrome,firefox"
 

--- a/packages/template-cli/templates/test/testcafe/fixtures/get-menu.test.cf.ts
+++ b/packages/template-cli/templates/test/testcafe/fixtures/get-menu.test.cf.ts
@@ -26,7 +26,7 @@ test("Returns the Latest menus component", async t => {
 })
 
 test("Create a new Yumido menu", async t => {
-    const createMenu = Selector("[title='Create menu']")
+    const createMenu = Selector("[aria-label='create menu button']")
     const menuName = Selector("#name")
     const menuDesc = Selector("#description")
     const menuActive = Selector("[name='enabled']")

--- a/packages/template-cli/templates/test/testcafe/fixtures/get-menu.test.cf.ts
+++ b/packages/template-cli/templates/test/testcafe/fixtures/get-menu.test.cf.ts
@@ -39,6 +39,7 @@ test("Create a new Yumido menu", async t => {
         .expect(menuList.innerText)
         .notContains(testMenuName)
         .click(createMenu)
+        .expect(menuName.exists).ok()
         .typeText(menuName, testMenuName)
         .typeText(menuDesc, "A delicous array of funky FE flavours")
         .click(menuActive)


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Fixes [AB#1523](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1523)

#### 🤔 Why
		
When the DOM is interacted with, the title is removed when the tooltip is displayed.
![Mar-19-2020 13-17-08](https://user-images.githubusercontent.com/47354603/77071449-f826b380-69e3-11ea-90fe-fe4696a347dc.gif)
		
#### 🛠 How
		
Remove selecting from title, use the static aria-label instead.

#### 👀 Evidence
		
```
Currently running in: production
Current url: http://dev.amidostacks.com/web/stacks
 Running tests in:
 - Chrome 72.0.3626.81 / macOS 10.14.6

 home
 ✓ Returns the Latest menus component
Successfully deleted menuId=f0e44f8a-312a-42cc-a409-f5f70f4a3c32 with status=204
deleteMenu response: 204
 ✓ Create a new Yumido menu
```

#### 🕵️ How to test

`npm run test:e2e`

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
