### PR TITLE
feat: list all non open packages in file on install

### DIFF
--- a/package-licenses.json
+++ b/package-licenses.json
@@ -45,6 +45,13 @@
     "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-license-ids",
     "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-license-ids/README.md"
   },
+  "spdx-ranges@2.1.1": {
+    "licenses": "(MIT AND CC-BY-3.0)",
+    "repository": "https://github.com/kemitchell/spdx-ranges.js",
+    "publisher": "The Linux Foundation",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-ranges",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-ranges/LICENSE.md"
+  },
   "tweetnacl@0.14.5": {
     "licenses": "Unlicense",
     "repository": "https://github.com/dchest/tweetnacl-js",

--- a/package-licenses.json
+++ b/package-licenses.json
@@ -1,0 +1,55 @@
+{
+  "caniuse-db@1.0.30001022": {
+    "licenses": "CC-BY-4.0",
+    "repository": "https://github.com/Fyrd/caniuse",
+    "publisher": "Alexis Deveria",
+    "email": "adeveria@gmail.com",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/caniuse-db",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/caniuse-db/LICENSE"
+  },
+  "caniuse-lite@1.0.30001022": {
+    "licenses": "CC-BY-4.0",
+    "repository": "https://github.com/ben-eb/caniuse-lite",
+    "publisher": "Ben Briggs",
+    "email": "beneb.info@gmail.com",
+    "url": "http://beneb.info",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/caniuse-lite",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/caniuse-lite/LICENSE"
+  },
+  "mdn-browser-compat-data@0.0.84": {
+    "licenses": "CC0-1.0",
+    "repository": "https://github.com/mdn/browser-compat-data",
+    "publisher": "MDN Web Docs",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/mdn-browser-compat-data",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/mdn-browser-compat-data/LICENSE"
+  },
+  "npm-lifecycle@3.1.4": {
+    "licenses": "Artistic-2.0",
+    "repository": "https://github.com/npm/lifecycle",
+    "publisher": "Mike Sherov",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/npm-lifecycle",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/npm-lifecycle/LICENSE"
+  },
+  "spdx-exceptions@2.2.0": {
+    "licenses": "CC-BY-3.0",
+    "repository": "https://github.com/kemitchell/spdx-exceptions.json",
+    "publisher": "The Linux Foundation",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-exceptions",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-exceptions/README.md"
+  },
+  "spdx-license-ids@3.0.5": {
+    "licenses": "CC0-1.0",
+    "repository": "https://github.com/shinnn/spdx-license-ids",
+    "publisher": "Shinnosuke Watanabe",
+    "url": "https://github.com/shinnn",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-license-ids",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/spdx-license-ids/README.md"
+  },
+  "tweetnacl@0.14.5": {
+    "licenses": "Unlicense",
+    "repository": "https://github.com/dchest/tweetnacl-js",
+    "publisher": "TweetNaCl-js contributors",
+    "path": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/tweetnacl",
+    "licenseFile": "/Users/estherlloyd/Documents/Github/stacks/stacks-webapp-template/node_modules/tweetnacl/LICENSE"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,9 +44,8 @@
     "lerna": "^3.20.2",
     "lint-staged": "^9.5.0",
     "prettier": "^1.19.1",
-    "typescript": "3.7.5"
+    "typescript": "3.7.5",
+    "license-checker": "^25.0.1"
   },
-  "dependencies": {
-    "yui-lint": "^0.2.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "https://amido.com",
   "license": "MIT",
   "scripts": {
-    "postinstall": "lerna bootstrap",
+    "license:check": "license-checker --json --excludePrivatePackage --out package-licenses.json --exclude 'MIT, MIT OR X11, BSD, ISC, Apache-2.0'",
+    "postinstall": "lerna bootstrap && npm run license:check",
     "dev": "lerna run dev --stream",
     "build": "lerna run build --stream",
     "test": "lerna run test --stream",
@@ -45,5 +46,7 @@
     "prettier": "^1.19.1",
     "typescript": "3.7.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "yui-lint": "^0.2.0"
+  }
 }


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Implements [AB#1446](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1446) .

#### 🤔 Why
		
Writes all the packages that the repo is consuming into a json file that are not one of the following opensource business friendly:

`MIT, MIT OR X11, BSD, ISC, Apache-2.0`
		
#### 🛠 How
		
Runs `postinstall`

#### 👀 Evidence
		
See `packages-licenses.json` for the output
		 
#### 🕵️ How to test

`npm run license:check`

OR

`npm install`

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [x Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
