### PR TITLE
task: Applitools tab Pipeline

### DIFF
--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
@@ -99,6 +99,7 @@ stages:
               component_test: false
               component_test_project: "$(Test.ComponentTestProjectPath)"
               cypress_e2e_test: true
+              cypress_applitools_test: true
               cypress_e2e_env_vars:
                 PORT: 3000
                 APP_BASE_URL: "http://localhost"

--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
@@ -99,6 +99,7 @@ stages:
               component_test: false
               component_test_project: "$(Test.ComponentTestProjectPath)"
               cypress_e2e_test: true
+              cypress_applitools_test: true
               cypress_e2e_env_vars:
                 PORT: 3000
                 APP_BASE_URL: "http://localhost"

--- a/packages/template-cli/templates/build/azDevops/azure/templates/steps/build-node.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/templates/steps/build-node.yml
@@ -35,6 +35,7 @@ parameters:
   audit_test: false
   contract_check_can_deploy: false
   cypress_e2e_test: true
+  cypress_applitools_test: false
   cypress_e2e_env_vars: {}
   # Build File Output
   build_file: false
@@ -114,6 +115,11 @@ steps:
         parameters:
           env_vars: ${{ parameters.cypress_e2e_env_vars}}
           workingDirectory: ${{ parameters.project_root_dir }}
+
+  # Visual regression tests running on locally built and hosted (undeployed)
+  - ${{ if eq(parameters.cypress_applitools_test, true) }}:
+      - task: ApplitoolsBuildTask@0
+        displayName: "Tests: Visual Regression with Applitools"
 
   # STEP build NPM for Azure registry
   - ${{ if eq(parameters.build_on_server, true) }}:

--- a/packages/template-cli/templates/src/ssr/applitools.config.js
+++ b/packages/template-cli/templates/src/ssr/applitools.config.js
@@ -1,5 +1,8 @@
 /*
-Global configuration properties
+Applitools Configuration File
+
+    To be saved at the same directory as cypress.json
+
     The following configuration properties cannot be defined using the first method of passing them to cy.eyesOpen.
     They should be defined either in the applitools.config.js file or as environment variables.
 
@@ -20,5 +23,10 @@ module.exports = {
     showLogs: true,
     saveDebugData: true,
     failCypressOnDiff: false, // If true, then the Cypress test fails if an eyes visual test fails. If false and an eyes test fails, then the Cypress test does not fail.
-    saveNewTests: true, // New tests are saved by default
+    saveNewTests: true, // New tests are saved by default,
+
+    // For CI purposed: obtain the batch name and ID from the environment variables
+    batchName: process.env.APPLITOOLS_BATCH_NAME,
+    batchId: process.env.APPLITOOLS_BATCH_ID
 }
+

--- a/packages/template-cli/templates/src/ssr/applitools.config.js
+++ b/packages/template-cli/templates/src/ssr/applitools.config.js
@@ -27,6 +27,5 @@ module.exports = {
 
     // For CI purposed: obtain the batch name and ID from the environment variables
     batchName: process.env.APPLITOOLS_BATCH_NAME,
-    batchId: process.env.APPLITOOLS_BATCH_ID
+    batchId: process.env.APPLITOOLS_BATCH_ID,
 }
-


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Implements [AB#1448](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1448)

#### 🤔 Why
		
Allow access to Applitools from the devops pipeline. Pass/fail results from the interface rather than on the Applitools dashboard.
		
#### 🛠 How
		
Enable the `ApplitoolsBuildtask@0` with the flag `cypress_applitools_test: true` in the pipeline.

#### 👀 Evidence
		
Currently failing due to being on a free tier account with Applitools. Ticket logged to get this changed.
![Screenshot 2020-03-23 at 11 20 00](https://user-images.githubusercontent.com/47354603/77311825-befa8600-6cf8-11ea-9d23-20b7cfd62bc4.png)

#### 🕵️ How to test

Run the pipeline.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
