### PR TITLE
feat: Lighthouse profile report in pipeline

### DIFF
--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
@@ -191,7 +191,8 @@ stages:
                             NODE_ENV: production
                           workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)/test/testcafe
                           testcafe_browser_list: "chrome,firefox"
+                  # Lighthouse profiling audit
                   - ${{ if eq(variables.lighthouse_audit, true) }}:
                       - task: Lighthouse@1
-                          inputs:
-                            url: "http://dev.amidostacks.com/web/stacks"
+                        inputs:
+                          url: "http://dev.amidostacks.com/web/stacks"

--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-existing-k8s.yml
@@ -54,6 +54,8 @@ variables:
   pool_vm_image: ubuntu-18.04
   # TestCafe E2E Tests
   testcafe_e2e_test: true
+  # Lighthouse Audit
+  lighthouse_audit: true
 
 stages:
   - stage: CI
@@ -189,3 +191,7 @@ stages:
                             NODE_ENV: production
                           workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)/test/testcafe
                           testcafe_browser_list: "chrome,firefox"
+                  - ${{ if eq(variables.lighthouse_audit, true) }}:
+                      - task: Lighthouse@1
+                          inputs:
+                            url: "http://dev.amidostacks.com/web/stacks"

--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
@@ -194,6 +194,6 @@ stages:
                           testcafe_browser_list: "chrome,firefox"
                   - ${{ if eq(variables.lighthouse_audit, true) }}:
                       - task: Lighthouse@1
-                          inputs:
-                            url: "http://dev.amidostacks.com/web/stacks"
+                        inputs:
+                          url: "http://dev.amidostacks.com/web/stacks"
 

--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
@@ -54,6 +54,10 @@ variables:
   pool_vm_image: ubuntu-18.04
   # Test setup
   deployed_base_url: https://stacks-webapp.com/foo
+  # TestCafe E2E Tests
+  testcafe_e2e_test: true
+  # Lighthouse Audit
+  lighthouse_audit: true
 
 stages:
   - stage: CI
@@ -188,4 +192,8 @@ stages:
                             NODE_ENV: production
                           workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)/test/testcafe
                           testcafe_browser_list: "chrome,firefox"
+                  - ${{ if eq(variables.lighthouse_audit, true) }}:
+                      - task: Lighthouse@1
+                          inputs:
+                            url: "http://dev.amidostacks.com/web/stacks"
 


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Implements [AB#678](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/678)

<!--
If you have accesss, to ink to the Azure Devops Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
Jack Shephard was rightly after a way to have a non-node version of lighthouse reporting that can be run in the pipeline.
		
#### 🛠 How
		
Added the Lighthouse task to the pipeline.

#### 👀 Evidence
		
<img width="1410" alt="Screenshot 2020-03-23 at 17 22 57" src="https://user-images.githubusercontent.com/47354603/77344923-cd15ca00-6d2b-11ea-8ec0-0529d673f9e9.png">

#### 🕵️ How to test

Run the pipeline, check the Lighthouse tab.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
