### PR TITLE
fix: remove nmprc file from template

### DIFF
--- a/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
+++ b/packages/template-cli/templates/build/azDevops/azure/azure-pipelines-ssr-new-k8s.yml
@@ -43,13 +43,13 @@ variables:
   docker_dockerfile_path: "src/"
   docker_image_name: stacks-webapp
   docker_image_tag: "$(version_major).$(version_minor).$(version_revision)-$(build.sourcebranchname)"
-  docker_container_registry_name: amidostacksdevcycle2
+  docker_container_registry_name: amidostacksnonprodnode
   # BUILD ARTIFACTS across stages
   build_artifact_deploy_path: $(Agent.BuildDirectory)/s/$(self_repo)/deploy/k8s/app
   build_artifact_deploy_name: stacks-webapp
   # AKS/AZURE
-  aks_clusterrg: amido-stacks-dev-cycle2
-  aks_clustername: amido-stacks-dev-cycle2
+  aks_clusterrg: amido-stacks-nonprod-node
+  aks_clustername: amido-stacks-nonprod-node
   # DEFAULT IMAGE RUNNER
   pool_vm_image: ubuntu-18.04
   # Test setup

--- a/packages/template-cli/templates/src/ssr/.npmrc
+++ b/packages/template-cli/templates/src/ssr/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/template-cli/templates/src/ssr/package-lock.json
+++ b/packages/template-cli/templates/src/ssr/package-lock.json
@@ -1,7 +1,8 @@
 {
-  "name": "webapp",
-  "requires": true,
+  "name": "PROJECT_NAME",
+  "version": "0.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@amidostacks/eslint-config": {
       "version": "0.20.3",


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

We no longer need an `.npmrc` file in the tempalted ssr app as there are no packages that are in private registries.

#### 🤔 Why
		
Otherwise the users will need to create a NPM_TOKEN that is being read in by the `npmrc` file by npm on install.
		
#### 🛠 How
		
Delete file.

#### 👀 Evidence
		
`npm i` returns all the packages no errors.
		 
#### 🕵️ How to test

`npm i`

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
