### PR TITLE
fix: Updates README with Windows instructions

### DIFF
--- a/libs/images/jenkins-dood/README.md
+++ b/libs/images/jenkins-dood/README.md
@@ -1,4 +1,4 @@
-# JENKINS 
+# JENKINS
 
 versions:
   - jenkins: lts (2.222.x)
@@ -6,11 +6,19 @@ versions:
 USAGE:
 ---
 ```bash
-docker build -t jenkins .
+docker build -t jenkins-dood .
 docker volume create jenkins-vol && \
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v $(which docker):/usr/bin/docker -v jenkins-vol:/var/jenkins_home --name jenkins -p 8080:8080 jenkins 
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v "$(which docker):/usr/bin/docker" -v jenkins-vol:/var/jenkins_home --name jenkins-dood -p 8080:8080 jenkins-dood
 docker start jenkins
 ```
+
+Note: If you're using Windows with Docker for Windows you'll need to change run command to the following:
+```bash
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v jenkins-vol:/var/jenkins_home --name jenkins-dood -p 8080:8080 jenkins-dood
+DOCKER_VERSION="$(docker -v | awk -F ' ' '{print substr($3, 1, length($3)-1)}')"
+docker exec -it jenkins-dood /bin/bash -c "wget https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz && tar -xvzf docker-$DOCKER_VERSION.tgz && ln -s /docker/docker /usr/bin/docker"
+```
+If you're using GitBash you may need to double up the slash on the Docker socket also: `... -v //var/run/docker.sock:/var/run/docker.sock ...`
 
 If you are running it for the first time
 ```bash
@@ -26,7 +34,7 @@ ARG DOTNET_CORE_VERSION=3.1
 ```
 
 Overwrite existing args in case you want to fork for custom purposes you could do something like below.
-then repeat the steps above to publish the fork into your own Docker repo. 
+then repeat the steps above to publish the fork into your own Docker repo.
 
 ```bash
 docker build -t amidostacks/ci-k8s:my-custom-version --build-arg TYPESCRIPT_VERSION=3.8.3 --build-arg KUBECTL_VERSION=1.17.1 .

--- a/libs/images/jenkins-dood/README.md
+++ b/libs/images/jenkins-dood/README.md
@@ -12,18 +12,22 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v "$(which docker):/
 docker start jenkins
 ```
 
-Note: If you're using Windows with Docker for Windows you'll need to change run command to the following:
+Note: If you're using Windows with Docker for Windows you'll need the following:
+  1. A `bash` shell such as Cygwin (or derivatives such as Babun) or GitBash.
+  2. Change run command above to the following:
 ```bash
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock -v jenkins-vol:/var/jenkins_home --name jenkins-dood -p 8080:8080 jenkins-dood
 DOCKER_VERSION="$(docker -v | awk -F ' ' '{print substr($3, 1, length($3)-1)}')"
 docker exec -it jenkins-dood /bin/bash -c "wget https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz && tar -xvzf docker-$DOCKER_VERSION.tgz && ln -s /docker/docker /usr/bin/docker"
 ```
-If you're using GitBash you may need to double up the slash on the Docker socket also: `... -v //var/run/docker.sock:/var/run/docker.sock ...`
+If you're using GitBash (not Cygwin) you may need to double up the slash on the Docker socket also: `... -v //var/run/docker.sock:/var/run/docker.sock ...`
+This is because GitBash auto translates paths to Windows paths always.
 
 If you are running it for the first time
 ```bash
 docker exec -it jenkins-dood /bin/bash -c "cat /var/jenkins_home/secrets/initialAdminPassword"
 ```
+Use this password to enter the Jenkins UI.
 
 Exposed args:
 ```


### PR DESCRIPTION
#### 📲 What

  - Updates `jenkins-dood` README to explain how to use Docker for
    Windows properly with `jenkins-dood`.
  - Makes the image tag and names consistent

#### 🤔 Why
		
Allows more consistent running of Jenkins, also allows people to use Windows with Docker for Windows and GitBash or other shells.


#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
