### PR TITLE
fix: adds `acme_email` param to prod deploy.

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.40.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/eslint-config@0.19.0...@amidostacks/eslint-config@0.40.0) (2020-07-21)
+
+
+### Bug Fixes
+
+* eslint peer deps list ([#108](https://github.com/amido/stacks-webapp-template/issues/108)) ([165f57f](https://github.com/amido/stacks-webapp-template/commit/165f57f97b77657c3099a4ddd53211eac34e7060))
+* lerna publishing  ([#104](https://github.com/amido/stacks-webapp-template/issues/104)) ([62ab904](https://github.com/amido/stacks-webapp-template/commit/62ab90463fab445c01d6579f6ee9893bba33aa12))
+* publishing with lerna ([#109](https://github.com/amido/stacks-webapp-template/issues/109)) ([b266275](https://github.com/amido/stacks-webapp-template/commit/b2662750098ee6084e3308584c5ad654ba65c6d0))
+* reduce package size ([259e745](https://github.com/amido/stacks-webapp-template/commit/259e74554e3e72ffb8e61f72accebd5e8e69c687))
+* version ([1f3f1ee](https://github.com/amido/stacks-webapp-template/commit/1f3f1ee661f29bdd2d16a11b7e5c1127f6cdf9b7))
+
+
+### Features
+
+* bump version ([d9fb33f](https://github.com/amido/stacks-webapp-template/commit/d9fb33f4c0512d2d72d05c96154949c20e5f6fd7))
+* pact-config package ([#148](https://github.com/amido/stacks-webapp-template/issues/148)) ([4343f21](https://github.com/amido/stacks-webapp-template/commit/4343f21850a55ddb6966f4a6d093c80562b950eb))
+* Search ([#119](https://github.com/amido/stacks-webapp-template/issues/119)) ([d4dbf04](https://github.com/amido/stacks-webapp-template/commit/d4dbf04cd4cbdd761de962f0c8388f02b6489497))
+
+
+
+
+
 # [0.39.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/eslint-config@0.19.0...@amidostacks/eslint-config@0.39.0) (2020-07-21)
 
 

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.41.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/eslint-config@0.19.0...@amidostacks/eslint-config@0.41.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* adds `acme_email` param to prod deploy. ([606f21e](https://github.com/amido/stacks-webapp-template/commit/606f21e53569912a50c1ae6e3421376b2ed18850))
+* eslint peer deps list ([#108](https://github.com/amido/stacks-webapp-template/issues/108)) ([165f57f](https://github.com/amido/stacks-webapp-template/commit/165f57f97b77657c3099a4ddd53211eac34e7060))
+* lerna publishing  ([#104](https://github.com/amido/stacks-webapp-template/issues/104)) ([62ab904](https://github.com/amido/stacks-webapp-template/commit/62ab90463fab445c01d6579f6ee9893bba33aa12))
+* publishing with lerna ([#109](https://github.com/amido/stacks-webapp-template/issues/109)) ([b266275](https://github.com/amido/stacks-webapp-template/commit/b2662750098ee6084e3308584c5ad654ba65c6d0))
+* reduce package size ([259e745](https://github.com/amido/stacks-webapp-template/commit/259e74554e3e72ffb8e61f72accebd5e8e69c687))
+* version ([1f3f1ee](https://github.com/amido/stacks-webapp-template/commit/1f3f1ee661f29bdd2d16a11b7e5c1127f6cdf9b7))
+
+
+### Features
+
+* bump version ([d9fb33f](https://github.com/amido/stacks-webapp-template/commit/d9fb33f4c0512d2d72d05c96154949c20e5f6fd7))
+* pact-config package ([#148](https://github.com/amido/stacks-webapp-template/issues/148)) ([4343f21](https://github.com/amido/stacks-webapp-template/commit/4343f21850a55ddb6966f4a6d093c80562b950eb))
+* Search ([#119](https://github.com/amido/stacks-webapp-template/issues/119)) ([d4dbf04](https://github.com/amido/stacks-webapp-template/commit/d4dbf04cd4cbdd761de962f0c8388f02b6489497))
+
+
+
+
+
 # [0.40.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/eslint-config@0.19.0...@amidostacks/eslint-config@0.40.0) (2020-07-21)
 
 

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/eslint-config",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/eslint-config",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/eslint-config",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Shared linting config from amido stacks",
   "main": "eslintrc.js",
   "author": "https://amido.com",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/eslint-config",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Shared linting config from amido stacks",
   "main": "eslintrc.js",
   "author": "https://amido.com",

--- a/packages/pact-config/CHANGELOG.md
+++ b/packages/pact-config/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.17.0 (2020-07-22)
+
+
+### Bug Fixes
+
+* adds `acme_email` param to prod deploy. ([606f21e](https://github.com/amido/stacks-webapp-template/commit/606f21e53569912a50c1ae6e3421376b2ed18850))
+* bootstrapping with lerna ([#279](https://github.com/amido/stacks-webapp-template/issues/279)) ([3ce3af4](https://github.com/amido/stacks-webapp-template/commit/3ce3af4ab809131347619a25e49cf4e7493f9fac))
+
+
+### Features
+
+* bump version ([d9fb33f](https://github.com/amido/stacks-webapp-template/commit/d9fb33f4c0512d2d72d05c96154949c20e5f6fd7))
+* pact-config package ([#148](https://github.com/amido/stacks-webapp-template/issues/148)) ([4343f21](https://github.com/amido/stacks-webapp-template/commit/4343f21850a55ddb6966f4a6d093c80562b950eb))
+
+
+
+
+
 # 0.16.0 (2020-07-21)
 
 

--- a/packages/pact-config/CHANGELOG.md
+++ b/packages/pact-config/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.16.0 (2020-07-21)
+
+
+### Bug Fixes
+
+* bootstrapping with lerna ([#279](https://github.com/amido/stacks-webapp-template/issues/279)) ([3ce3af4](https://github.com/amido/stacks-webapp-template/commit/3ce3af4ab809131347619a25e49cf4e7493f9fac))
+
+
+### Features
+
+* bump version ([d9fb33f](https://github.com/amido/stacks-webapp-template/commit/d9fb33f4c0512d2d72d05c96154949c20e5f6fd7))
+* pact-config package ([#148](https://github.com/amido/stacks-webapp-template/issues/148)) ([4343f21](https://github.com/amido/stacks-webapp-template/commit/4343f21850a55ddb6966f4a6d093c80562b950eb))
+
+
+
+
+
 # 0.15.0 (2020-07-21)
 
 

--- a/packages/pact-config/package-lock.json
+++ b/packages/pact-config/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/pact-config",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/pact-config/package-lock.json
+++ b/packages/pact-config/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/pact-config",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/pact-config/package.json
+++ b/packages/pact-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/pact-config",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": "Amido Stacks <stacks@amido.com>",
   "description": "Pact Jest wrapper and executables for consumers",
   "main": "./dist/index.js",

--- a/packages/pact-config/package.json
+++ b/packages/pact-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/pact-config",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "Amido Stacks <stacks@amido.com>",
   "description": "Pact Jest wrapper and executables for consumers",
   "main": "./dist/index.js",

--- a/packages/scaffolding-cli/CHANGELOG.md
+++ b/packages/scaffolding-cli/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.42.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/scaffolding-cli@1.12.1...@amidostacks/scaffolding-cli@1.42.0) (2020-07-21)
+
+
+### Bug Fixes
+
+* bootstrapping with lerna ([#279](https://github.com/amido/stacks-webapp-template/issues/279)) ([3ce3af4](https://github.com/amido/stacks-webapp-template/commit/3ce3af4ab809131347619a25e49cf4e7493f9fac))
+* bumps appgateway version ([68a8656](https://github.com/amido/stacks-webapp-template/commit/68a8656d6fc91e7efb5a20013d20d1d40c07cbde))
+* cms blog ui ([#283](https://github.com/amido/stacks-webapp-template/issues/283)) ([fee1d83](https://github.com/amido/stacks-webapp-template/commit/fee1d8327881fcd75dacd0e766b739f634f1b560))
+* corrected GCP app mapping ([#386](https://github.com/amido/stacks-webapp-template/issues/386)) ([2f303e8](https://github.com/amido/stacks-webapp-template/commit/2f303e82aa956a6d1a56342412ae3467a6d23db1))
+* csr favicon & searchbar ([#142](https://github.com/amido/stacks-webapp-template/issues/142)) ([7bf1b6a](https://github.com/amido/stacks-webapp-template/commit/7bf1b6a59b5d5de302b8347916266f2a793cf359))
+* csr properly ported in cli flow ([#317](https://github.com/amido/stacks-webapp-template/issues/317)) ([326b7ee](https://github.com/amido/stacks-webapp-template/commit/326b7ee40e055eae680b7ca13f955d07b3c70013))
+* deploy artifact ([30ab8ee](https://github.com/amido/stacks-webapp-template/commit/30ab8eee88a22df2554279149180a1b8332b13c3))
+* merge master into branch ([56444d0](https://github.com/amido/stacks-webapp-template/commit/56444d0e4f060738822c0d4059ba7e90ce021000))
+* more lint changes ([3633fcc](https://github.com/amido/stacks-webapp-template/commit/3633fccd627d131dd369822a30af86488f769c6d))
+* patch env vars for csr ([ee7a70f](https://github.com/amido/stacks-webapp-template/commit/ee7a70f5be24c4d501c357d103d85d46d9dc7067))
+* reduce package size ([259e745](https://github.com/amido/stacks-webapp-template/commit/259e74554e3e72ffb8e61f72accebd5e8e69c687))
+* redundant calls to the search api ([#161](https://github.com/amido/stacks-webapp-template/issues/161)) ([6694a37](https://github.com/amido/stacks-webapp-template/commit/6694a37dd7b516c675c90b11ec49c753590c6e90))
+* security headers default helmet ([#367](https://github.com/amido/stacks-webapp-template/issues/367)) ([e63adac](https://github.com/amido/stacks-webapp-template/commit/e63adacef97037ceb4c653690fba840ff92a238b))
+* spacing issue on tfoutputs ([2963c43](https://github.com/amido/stacks-webapp-template/commit/2963c4329b861965f8c92e77f5f82bd4648742b4))
+* testcafe running with correct api with setup ([c8e3e6a](https://github.com/amido/stacks-webapp-template/commit/c8e3e6a2df51df055dbae2034812b905076120e9))
+* tf libs versioning updated ([6696289](https://github.com/amido/stacks-webapp-template/commit/669628972103228b9b0fa7f1bc1875993bd6cba1))
+* type error ([#347](https://github.com/amido/stacks-webapp-template/issues/347)) ([fbad081](https://github.com/amido/stacks-webapp-template/commit/fbad0819b57833aca745b0296f0e5bc6f4e898a7))
+
+
+### Features
+
+* added appInsights to CSR ([#164](https://github.com/amido/stacks-webapp-template/issues/164)) ([eb29288](https://github.com/amido/stacks-webapp-template/commit/eb2928872f0a87f0966470f300f6570aab87bc5c))
+* added Auth0 and /profile page ([#351](https://github.com/amido/stacks-webapp-template/issues/351)) ([a053626](https://github.com/amido/stacks-webapp-template/commit/a053626c058b64e6dd63d3d2e057d1be4a8868c9))
+* added Redux sagas and api integration ([#156](https://github.com/amido/stacks-webapp-template/issues/156)) ([c090fef](https://github.com/amido/stacks-webapp-template/commit/c090fef619d6b19c5e393bed91dbfe89606cbb9d))
+* Adds a Production Stacks cluster on master ([917dcb3](https://github.com/amido/stacks-webapp-template/commit/917dcb3dfc9d0fb088b427d2d068fd024daf4c81))
+* bump version ([d9fb33f](https://github.com/amido/stacks-webapp-template/commit/d9fb33f4c0512d2d72d05c96154949c20e5f6fd7))
+* CMS i18n integration ([#345](https://github.com/amido/stacks-webapp-template/issues/345)) ([1833736](https://github.com/amido/stacks-webapp-template/commit/18337369d7174cb6ea827545a1e084c791e62c13))
+* CRA (ejected) ([#131](https://github.com/amido/stacks-webapp-template/issues/131)) ([22be82c](https://github.com/amido/stacks-webapp-template/commit/22be82c8ae37be764cb2bf483a1eedb1e4b5fee3))
+* cypress with csr ([#159](https://github.com/amido/stacks-webapp-template/issues/159)) ([90e7281](https://github.com/amido/stacks-webapp-template/commit/90e7281f7e59152455811ffb00fb4d9789452a31))
+* delete menu after creation ([79a8936](https://github.com/amido/stacks-webapp-template/commit/79a8936edd49be2d914733e3f82052918ba800b8))
+* integrated with Contentful CMS ([#240](https://github.com/amido/stacks-webapp-template/issues/240)) ([a8cc522](https://github.com/amido/stacks-webapp-template/commit/a8cc5227dd108ecbb65931ee6a4bad33e6088e5c))
+* Lighthouse docker image and example ([#278](https://github.com/amido/stacks-webapp-template/issues/278)) ([2b69735](https://github.com/amido/stacks-webapp-template/commit/2b69735275cd8d8ed5ccae2bda0513324d8a53ee))
+* pact-config package ([#148](https://github.com/amido/stacks-webapp-template/issues/148)) ([4343f21](https://github.com/amido/stacks-webapp-template/commit/4343f21850a55ddb6966f4a6d093c80562b950eb))
+* Update Build Pipeline for AZD ([#384](https://github.com/amido/stacks-webapp-template/issues/384)) ([b2dd53b](https://github.com/amido/stacks-webapp-template/commit/b2dd53b3d4aea3eeadcab5b2c15dcde7f0e67320))
+
+
+
+## 0.0.2 (2020-04-28)
+
+
+### Bug Fixes
+
+* removed app Insights key from public ([#125](https://github.com/amido/stacks-webapp-template/issues/125)) ([bb16b1a](https://github.com/amido/stacks-webapp-template/commit/bb16b1a63d47618d82f94bb395e306e8bd792236))
+
+
+### Features
+
+* Search ([#119](https://github.com/amido/stacks-webapp-template/issues/119)) ([d4dbf04](https://github.com/amido/stacks-webapp-template/commit/d4dbf04cd4cbdd761de962f0c8388f02b6489497))
+* search helper text ([#124](https://github.com/amido/stacks-webapp-template/issues/124)) ([fa89290](https://github.com/amido/stacks-webapp-template/commit/fa89290a74062e7de46be859c3b2fda1b2eb475e))
+* search input throttled. ([#123](https://github.com/amido/stacks-webapp-template/issues/123)) ([86842b7](https://github.com/amido/stacks-webapp-template/commit/86842b7c5b885d3c140c47eea0ed3126e680cfa4))
+
+
+
+
+
 # [1.41.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/scaffolding-cli@1.12.1...@amidostacks/scaffolding-cli@1.41.0) (2020-07-21)
 
 

--- a/packages/scaffolding-cli/CHANGELOG.md
+++ b/packages/scaffolding-cli/CHANGELOG.md
@@ -3,6 +3,69 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.43.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/scaffolding-cli@1.12.1...@amidostacks/scaffolding-cli@1.43.0) (2020-07-22)
+
+
+### Bug Fixes
+
+* adds `acme_email` param to prod deploy. ([606f21e](https://github.com/amido/stacks-webapp-template/commit/606f21e53569912a50c1ae6e3421376b2ed18850))
+* bootstrapping with lerna ([#279](https://github.com/amido/stacks-webapp-template/issues/279)) ([3ce3af4](https://github.com/amido/stacks-webapp-template/commit/3ce3af4ab809131347619a25e49cf4e7493f9fac))
+* bumps appgateway version ([68a8656](https://github.com/amido/stacks-webapp-template/commit/68a8656d6fc91e7efb5a20013d20d1d40c07cbde))
+* cms blog ui ([#283](https://github.com/amido/stacks-webapp-template/issues/283)) ([fee1d83](https://github.com/amido/stacks-webapp-template/commit/fee1d8327881fcd75dacd0e766b739f634f1b560))
+* corrected GCP app mapping ([#386](https://github.com/amido/stacks-webapp-template/issues/386)) ([2f303e8](https://github.com/amido/stacks-webapp-template/commit/2f303e82aa956a6d1a56342412ae3467a6d23db1))
+* csr favicon & searchbar ([#142](https://github.com/amido/stacks-webapp-template/issues/142)) ([7bf1b6a](https://github.com/amido/stacks-webapp-template/commit/7bf1b6a59b5d5de302b8347916266f2a793cf359))
+* csr properly ported in cli flow ([#317](https://github.com/amido/stacks-webapp-template/issues/317)) ([326b7ee](https://github.com/amido/stacks-webapp-template/commit/326b7ee40e055eae680b7ca13f955d07b3c70013))
+* deploy artifact ([30ab8ee](https://github.com/amido/stacks-webapp-template/commit/30ab8eee88a22df2554279149180a1b8332b13c3))
+* merge master into branch ([56444d0](https://github.com/amido/stacks-webapp-template/commit/56444d0e4f060738822c0d4059ba7e90ce021000))
+* more lint changes ([3633fcc](https://github.com/amido/stacks-webapp-template/commit/3633fccd627d131dd369822a30af86488f769c6d))
+* patch env vars for csr ([ee7a70f](https://github.com/amido/stacks-webapp-template/commit/ee7a70f5be24c4d501c357d103d85d46d9dc7067))
+* reduce package size ([259e745](https://github.com/amido/stacks-webapp-template/commit/259e74554e3e72ffb8e61f72accebd5e8e69c687))
+* redundant calls to the search api ([#161](https://github.com/amido/stacks-webapp-template/issues/161)) ([6694a37](https://github.com/amido/stacks-webapp-template/commit/6694a37dd7b516c675c90b11ec49c753590c6e90))
+* rename KeyVaults due to collisions ([029998b](https://github.com/amido/stacks-webapp-template/commit/029998b90852646afed3b82b461e0311b413b933))
+* security headers default helmet ([#367](https://github.com/amido/stacks-webapp-template/issues/367)) ([e63adac](https://github.com/amido/stacks-webapp-template/commit/e63adacef97037ceb4c653690fba840ff92a238b))
+* spacing issue on tfoutputs ([2963c43](https://github.com/amido/stacks-webapp-template/commit/2963c4329b861965f8c92e77f5f82bd4648742b4))
+* testcafe running with correct api with setup ([c8e3e6a](https://github.com/amido/stacks-webapp-template/commit/c8e3e6a2df51df055dbae2034812b905076120e9))
+* tf libs versioning updated ([6696289](https://github.com/amido/stacks-webapp-template/commit/669628972103228b9b0fa7f1bc1875993bd6cba1))
+* type error ([#347](https://github.com/amido/stacks-webapp-template/issues/347)) ([fbad081](https://github.com/amido/stacks-webapp-template/commit/fbad0819b57833aca745b0296f0e5bc6f4e898a7))
+* uncomments gates again now build passes ([e2fde68](https://github.com/amido/stacks-webapp-template/commit/e2fde68149691b704b52da4487f1539900cc104a))
+
+
+### Features
+
+* added appInsights to CSR ([#164](https://github.com/amido/stacks-webapp-template/issues/164)) ([eb29288](https://github.com/amido/stacks-webapp-template/commit/eb2928872f0a87f0966470f300f6570aab87bc5c))
+* added Auth0 and /profile page ([#351](https://github.com/amido/stacks-webapp-template/issues/351)) ([a053626](https://github.com/amido/stacks-webapp-template/commit/a053626c058b64e6dd63d3d2e057d1be4a8868c9))
+* added Redux sagas and api integration ([#156](https://github.com/amido/stacks-webapp-template/issues/156)) ([c090fef](https://github.com/amido/stacks-webapp-template/commit/c090fef619d6b19c5e393bed91dbfe89606cbb9d))
+* Adds a Production Stacks cluster on master ([917dcb3](https://github.com/amido/stacks-webapp-template/commit/917dcb3dfc9d0fb088b427d2d068fd024daf4c81))
+* bump version ([d9fb33f](https://github.com/amido/stacks-webapp-template/commit/d9fb33f4c0512d2d72d05c96154949c20e5f6fd7))
+* CMS i18n integration ([#345](https://github.com/amido/stacks-webapp-template/issues/345)) ([1833736](https://github.com/amido/stacks-webapp-template/commit/18337369d7174cb6ea827545a1e084c791e62c13))
+* CRA (ejected) ([#131](https://github.com/amido/stacks-webapp-template/issues/131)) ([22be82c](https://github.com/amido/stacks-webapp-template/commit/22be82c8ae37be764cb2bf483a1eedb1e4b5fee3))
+* cypress with csr ([#159](https://github.com/amido/stacks-webapp-template/issues/159)) ([90e7281](https://github.com/amido/stacks-webapp-template/commit/90e7281f7e59152455811ffb00fb4d9789452a31))
+* delete menu after creation ([79a8936](https://github.com/amido/stacks-webapp-template/commit/79a8936edd49be2d914733e3f82052918ba800b8))
+* integrated with Contentful CMS ([#240](https://github.com/amido/stacks-webapp-template/issues/240)) ([a8cc522](https://github.com/amido/stacks-webapp-template/commit/a8cc5227dd108ecbb65931ee6a4bad33e6088e5c))
+* Lighthouse docker image and example ([#278](https://github.com/amido/stacks-webapp-template/issues/278)) ([2b69735](https://github.com/amido/stacks-webapp-template/commit/2b69735275cd8d8ed5ccae2bda0513324d8a53ee))
+* pact-config package ([#148](https://github.com/amido/stacks-webapp-template/issues/148)) ([4343f21](https://github.com/amido/stacks-webapp-template/commit/4343f21850a55ddb6966f4a6d093c80562b950eb))
+* Update Build Pipeline for AZD ([#384](https://github.com/amido/stacks-webapp-template/issues/384)) ([b2dd53b](https://github.com/amido/stacks-webapp-template/commit/b2dd53b3d4aea3eeadcab5b2c15dcde7f0e67320))
+
+
+
+## 0.0.2 (2020-04-28)
+
+
+### Bug Fixes
+
+* removed app Insights key from public ([#125](https://github.com/amido/stacks-webapp-template/issues/125)) ([bb16b1a](https://github.com/amido/stacks-webapp-template/commit/bb16b1a63d47618d82f94bb395e306e8bd792236))
+
+
+### Features
+
+* Search ([#119](https://github.com/amido/stacks-webapp-template/issues/119)) ([d4dbf04](https://github.com/amido/stacks-webapp-template/commit/d4dbf04cd4cbdd761de962f0c8388f02b6489497))
+* search helper text ([#124](https://github.com/amido/stacks-webapp-template/issues/124)) ([fa89290](https://github.com/amido/stacks-webapp-template/commit/fa89290a74062e7de46be859c3b2fda1b2eb475e))
+* search input throttled. ([#123](https://github.com/amido/stacks-webapp-template/issues/123)) ([86842b7](https://github.com/amido/stacks-webapp-template/commit/86842b7c5b885d3c140c47eea0ed3126e680cfa4))
+
+
+
+
+
 # [1.42.0](https://github.com/amido/stacks-webapp-template/compare/@amidostacks/scaffolding-cli@1.12.1...@amidostacks/scaffolding-cli@1.42.0) (2020-07-21)
 
 

--- a/packages/scaffolding-cli/package-lock.json
+++ b/packages/scaffolding-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/scaffolding-cli",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/scaffolding-cli/package-lock.json
+++ b/packages/scaffolding-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/scaffolding-cli",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/scaffolding-cli/package.json
+++ b/packages/scaffolding-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/scaffolding-cli",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "scaffolding-cli creates a scaffolded folder with deploy, build and src folders ready to be committed to a Git repo of your choosing",
   "bin": {
     "scaffolding-cli": "./dist/index.js",
@@ -33,7 +33,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@amidostacks/eslint-config": "^0.40.0",
+    "@amidostacks/eslint-config": "^0.41.0",
     "@types/concat-stream": "^1.6.0",
     "@types/fs-extra": "^9.0.1",
     "@types/jest": "^25.2.3",

--- a/packages/scaffolding-cli/package.json
+++ b/packages/scaffolding-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amidostacks/scaffolding-cli",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "scaffolding-cli creates a scaffolded folder with deploy, build and src folders ready to be committed to a Git repo of your choosing",
   "bin": {
     "scaffolding-cli": "./dist/index.js",
@@ -33,7 +33,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@amidostacks/eslint-config": "^0.39.0",
+    "@amidostacks/eslint-config": "^0.40.0",
     "@types/concat-stream": "^1.6.0",
     "@types/fs-extra": "^9.0.1",
     "@types/jest": "^25.2.3",

--- a/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
+++ b/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
@@ -238,7 +238,7 @@ stages:
             domain_filter: $(base_domain_nonprod)
 
   - stage: prod
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
     # You can find notes in the READMEs around which values to use for each ENV variable group
     - group: amido-stacks-infra-credentials-prod
@@ -312,7 +312,7 @@ stages:
               for i in "${outputs[@]}"; do echo "$i"; done
 
     - job: K8sProd
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       dependsOn: InfraProd
       variables:
         AKS_DEFAULT_USER_IDENTITY_CLIENT_ID: $[ dependencies.InfraProd.outputs['tfoutputs.AKS_DEFAULT_USER_IDENTITY_CLIENT_ID'] ]

--- a/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
+++ b/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
@@ -119,7 +119,7 @@ stages:
             project: 'stacks'
             environment: ''
             azure_cli_providers: [
-              { name: MSIPreview, namespace: Microsoft.ContainerService }
+              { name: MSIPreview, namespace: Microsoft.ContainerService },
             ]
             # Azure config
             tags: ''
@@ -139,7 +139,7 @@ stages:
               TF_VAR_stage: nonprod,
               TF_VAR_key_vault_name: "core-nonprod-vault",
               TF_VAR_dns_zone: $(base_domain_nonprod),
-              TF_VAR_internal_dns_zone: $(base_domain_internal_nonprod)
+              TF_VAR_internal_dns_zone: $(base_domain_internal_nonprod),
             }
             terraform_output_commands: |
               raw_tf=$(terraform output -json | jq -r 'keys[] as $k | "##vso[task.setvariable variable=\($k | ascii_upcase);isOutput=true]\(.[$k] | .value)"')
@@ -182,7 +182,7 @@ stages:
                 displayName: ExternalDns,
                 env_vars: {
                   domain_filter: $(base_domain_nonprod),
-                  aks_resource_group: $(AKS_RESOURCE_GROUP)
+                  aks_resource_group: $(AKS_RESOURCE_GROUP),
                 },
                 args: "-no-empty"
               },
@@ -192,7 +192,7 @@ stages:
                 env_vars: {
                   user_identity_id: $(AKS_DEFAULT_USER_IDENTITY_ID),
                   identity_client_id: $(AKS_DEFAULT_USER_IDENTITY_CLIENT_ID),
-                  identity_user_name: $(AKS_DEFAULT_USER_IDENTITY_NAME)
+                  identity_user_name: $(AKS_DEFAULT_USER_IDENTITY_NAME),
                 },
                 args: "-no-empty"
               },
@@ -200,7 +200,7 @@ stages:
                 base: $(Agent.BuildDirectory)/s/$(self_repo)/build/k8s_manifests/aks/base_aadpodidentitybinding.yml,
                 displayName: AADPodIdBinding,
                 env_vars: {
-                  identity_user_name: $(AKS_DEFAULT_USER_IDENTITY_NAME)
+                  identity_user_name: $(AKS_DEFAULT_USER_IDENTITY_NAME),
                 },
                 args: "-no-empty"
               },
@@ -210,7 +210,7 @@ stages:
                 displayName: NginxIngress,
                 env_vars: {
                   aks_ingress_ip: $(AKS_INGRESS_PRIVATE_IP),
-                  LB_IS_INTERNAL: "true"
+                  LB_IS_INTERNAL: "true",
                 },
                 args: "-no-empty"
               }
@@ -284,7 +284,7 @@ stages:
             project: 'stacks'
             environment: ''
             azure_cli_providers: [
-              { name: MSIPreview, namespace: Microsoft.ContainerService }
+              { name: MSIPreview, namespace: Microsoft.ContainerService },
             ]
             # Azure config
             tags: ''
@@ -298,12 +298,13 @@ stages:
               TF_VAR_name_component: $(domain),
               TF_VAR_name_environment: prod,
               TF_VAR_create_acr: true,
+              TF_VAR_acme_email: "stacks@amido.com",
               TF_VAR_is_cluster_private: true,
               TF_VAR_cluster_version: $(aks_cluster_version),
               TF_VAR_stage: prod,
               TF_VAR_key_vault_name: "core-prod-vault",
               TF_VAR_dns_zone: $(base_domain_prod),
-              TF_VAR_internal_dns_zone: $(base_domain_internal_prod)
+              TF_VAR_internal_dns_zone: $(base_domain_internal_prod),
             }
             terraform_output_commands: |
               raw_tf=$(terraform output -json | jq -r 'keys[] as $k | "##vso[task.setvariable variable=\($k | ascii_upcase);isOutput=true]\(.[$k] | .value)"')
@@ -347,7 +348,7 @@ stages:
                 displayName: ExternalDns,
                 env_vars: {
                   domain_filter: $(base_domain_prod),
-                  aks_resource_group: $(AKS_RESOURCE_GROUP)
+                  aks_resource_group: $(AKS_RESOURCE_GROUP),
                 },
                 args: "-no-empty"
               },
@@ -357,7 +358,7 @@ stages:
                 env_vars: {
                   user_identity_id: $(AKS_DEFAULT_USER_IDENTITY_ID),
                   identity_client_id: $(AKS_DEFAULT_USER_IDENTITY_CLIENT_ID),
-                  identity_user_name: $(AKS_DEFAULT_USER_IDENTITY_NAME)
+                  identity_user_name: $(AKS_DEFAULT_USER_IDENTITY_NAME),
                 },
                 args: "-no-empty"
               },
@@ -375,7 +376,7 @@ stages:
                 displayName: NginxIngress,
                 env_vars: {
                   aks_ingress_ip: $(AKS_INGRESS_PRIVATE_IP),
-                  LB_IS_INTERNAL: "true"
+                  LB_IS_INTERNAL: "true",
                 },
                 args: "-no-empty"
               }
@@ -392,7 +393,7 @@ stages:
             aks_aad_pod_identity: true
             aks_aad_pod_identity_yaml: {
               aad_id_yml: $(Agent.BuildDirectory)/s/$(self_repo)/build/k8s_manifests/aks/aadpodidentity.yml,
-              aad_id_binding_yml: $(Agent.BuildDirectory)/s/$(self_repo)/build/k8s_manifests/aks/aadpodidentitybinding.yml
+              aad_id_binding_yml: $(Agent.BuildDirectory)/s/$(self_repo)/build/k8s_manifests/aks/aadpodidentitybinding.yml,
             }
             acr_name: $(docker_container_registry_name)
             acr_resource_group_name: $(AKS_RESOURCE_GROUP)

--- a/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
+++ b/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
@@ -238,7 +238,7 @@ stages:
             domain_filter: $(base_domain_nonprod)
 
   - stage: prod
-    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
     # You can find notes in the READMEs around which values to use for each ENV variable group
     - group: amido-stacks-infra-credentials-prod
@@ -312,7 +312,7 @@ stages:
               for i in "${outputs[@]}"; do echo "$i"; done
 
     - job: K8sProd
-      # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       dependsOn: InfraProd
       variables:
         AKS_DEFAULT_USER_IDENTITY_CLIENT_ID: $[ dependencies.InfraProd.outputs['tfoutputs.AKS_DEFAULT_USER_IDENTITY_CLIENT_ID'] ]

--- a/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
+++ b/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
@@ -137,7 +137,7 @@ stages:
               TF_VAR_is_cluster_private: true,
               TF_VAR_cluster_version: $(aks_cluster_version),
               TF_VAR_stage: nonprod,
-              TF_VAR_key_vault_name: "core-nonprod-vault",
+              TF_VAR_key_vault_name: "stacks-core-nonprod",
               TF_VAR_dns_zone: $(base_domain_nonprod),
               TF_VAR_internal_dns_zone: $(base_domain_internal_nonprod),
             }
@@ -302,7 +302,7 @@ stages:
               TF_VAR_is_cluster_private: true,
               TF_VAR_cluster_version: $(aks_cluster_version),
               TF_VAR_stage: prod,
-              TF_VAR_key_vault_name: "core-prod-vault",
+              TF_VAR_key_vault_name: "stacks-core-prod",
               TF_VAR_dns_zone: $(base_domain_prod),
               TF_VAR_internal_dns_zone: $(base_domain_internal_prod),
             }


### PR DESCRIPTION
#### 📲 What

A fix for the previous PR adding `acme_email` to the Prod AKS deploy in Azure DevOps.
#### 🤔 Why
		
The previous release breaks due to not having the parameter.
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 Evidence
		
![image](https://user-images.githubusercontent.com/2286713/88093211-9771d800-cb89-11ea-9fd1-498541763354.png)


#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
