### PR TITLE
fix: Adds X-Forward header reading to nginx

### DIFF
--- a/packages/scaffolding-cli/templates/build/k8s_manifests/aks/base_nginx-ingress.yml
+++ b/packages/scaffolding-cli/templates/build/k8s_manifests/aks/base_nginx-ingress.yml
@@ -16,7 +16,8 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-
+data:
+  use-forwarded-headers: "true"
 ---
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
#### 📲 What

This adds a value to the nginx ingress configmap to read the `X-Forward-*` headers set by Application Gateway

#### 🤔 Why
		
This is needed for two reasons:
  1.) This allows pods to get the IP address of the incoming request, rather than the Internal IP of Application Gateway.
  2.) If you set `ssl-redirect` to true, you end up with an infinite redirect loop as Nginx ignores the forwarded protocol from the user and so it always thinks the incoming requests are under `http` and so issues a redirect to `https`.
		
#### 👀 Evidence
	
![image](https://user-images.githubusercontent.com/2286713/88807785-124e7a80-d1aa-11ea-80a1-26fec1df1805.png)

