### PR TITLE
feat: Adds Yamllint to `ci-k8s` image

### DIFF
--- a/libs/images/jenkins-dood/plugins.txt
+++ b/libs/images/jenkins-dood/plugins.txt
@@ -2,3 +2,4 @@ scm-api:latest
 git-client:latest
 git:latest
 blueocean:latest
+jacoco:latest

--- a/libs/images/k8s-deploy/Dockerfile
+++ b/libs/images/k8s-deploy/Dockerfile
@@ -4,6 +4,7 @@ ARG KUBECTL_VERSION=1.16.10
 ARG KUSTOMIZE_VERSION=3.5.4
 ARG TYPESCRIPT_VERSION=3.7.5
 ARG DOTNET_CORE_VERSION=3.1
+ARG YAMLLINT_VERSION=1.24.2
 
 LABEL maintainer="Amido Stacks <stacks@amido.com>"
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
@@ -58,6 +59,10 @@ RUN apt-get install -y apt-transport-https && \
     apt-get update -y && \
     apt-get install -y dotnet-sdk-${DOTNET_CORE_VERSION} && \
     apt-get install -y aspnetcore-runtime-${DOTNET_CORE_VERSION}
+
+# YAMLLint
+RUN apt-get install -y python3 python3-pip && \
+	pip3 install "yamllint==${YAMLLINT_VERSION}"
 
 # Install GCLOUD CLI
 # Add the Cloud SDK distribution URI as a package source

--- a/libs/images/k8s-deploy/README.md
+++ b/libs/images/k8s-deploy/README.md
@@ -19,6 +19,7 @@ versions:
     - core 2020.04.24
     - gsutil 4.49
     - docker-credential-gcr 2.0.1
+  - yamllint: 1.24.2
 
 Includes envsubst cli for template parsing with environment variables.
 
@@ -31,6 +32,7 @@ ARG KUBECTL_VERSION=1.16.10
 ARG KUSTOMIZE_VERSION=3.5.4
 ARG TYPESCRIPT_VERSION=3.7.5
 ARG DOTNET_CORE_VERSION=3.1
+ARG YAMLLINT=1.24.2
 ```
 
 Overwrite existing args in case you want to fork for custom purposes you could do something like below.


### PR DESCRIPTION
#### 📲 What

  * Adds Yamllint to `ci-k8s` image
  * Also adds `jacoco:latest` to Jenkins plugins

#### 🤔 Why
		
To be able to run `yamllint` as part of a pipeline inside a Docker image.

Also to be able to upload JaCoCo coverage reports to Jenkins
