### PR TITLE
fix: use correct tf_state_key for azure

### DIFF
--- a/packages/scaffolding-cli/src/domain/config/worker_maps/infra_aks_tfs.ts
+++ b/packages/scaffolding-cli/src/domain/config/worker_maps/infra_aks_tfs.ts
@@ -22,7 +22,7 @@ export const inFiles = ({
                 "domain: core": `domain: ${businessObj?.domain}`,
                 "self_repo_tf_src: deploy/azure/infra/stacks-aks": "self_repo_tf_src: deploy/azure/infra",
                 "region: northeurope": `region: ${cloudObj.region}`,
-                "tf_state_key: stacks-core": "tf_state_key: $(project)-$(domain)",
+                "tf_state_key: core-sharedservices": "tf_state_key: $(project)-$(domain)",
                 "amidostacks.com": `${networkObj?.baseDomain}`,
                 "TF_VAR_acme_email: \"stacks@amido.com\"": "TF_VAR_acme_email: \"%REPLACE_ME_FOR_ACME_EMAIL_ADDRESS%\""
             }

--- a/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
+++ b/packages/scaffolding-cli/templates/build/azDevops/azure/azure-pipeline-infrastructure-aks.yml
@@ -56,7 +56,7 @@ variables:
   # **`terraform_state_workspace: `** all states will be saved under this key for this definition
   # avoid running anything past dev that is not on master
   # sample value: sharedservices
-  tf_state_key: stacks-core
+  tf_state_key: core-sharedservices
   # Scripts directory used by pipeline steps
   scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
   # AKS/AZURE


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

A description of the change.

<!--
If you have access, to ink to the Azure DevOps Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
Why it's needed, background context.
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
