### PR TITLE
chore(tf): bump tf version to 0.13.1

### DIFF
--- a/libs/images/tf-deploy/Dockerfile
+++ b/libs/images/tf-deploy/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10.3
 
-ARG TF_VERSION=0.12.28
+ARG TF_VERSION=0.13.1
 
 LABEL maintainer="Amido Stacks <stacks@amido.com>"
 


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Bump terraform version to 0.13.1

<!--
If you have access, to ink to the Azure DevOps Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
Need to use a slightly newer version 
		
#### 🛠 How
		
Updated argument in the dockerfile

#### 👀 Evidence

Locally the image builds successfully for me
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
