### PR TITLE
chore: use ubuntu base image for k8s-deploy and tf-deploy images

### DIFF
--- a/libs/images/k8s-deploy/Dockerfile
+++ b/libs/images/k8s-deploy/Dockerfile
@@ -1,11 +1,12 @@
-FROM debian:11-slim
+FROM ubuntu:20.04
 
 ARG KUBECTL_VERSION=1.16.10
 ARG KUSTOMIZE_VERSION=3.5.4
 ARG TYPESCRIPT_VERSION=3.7.5
 ARG DOTNET_CORE_VERSION=3.1
 ARG YAMLLINT_VERSION=1.24.2
-ARG AZURE_CLI_VERSION=2.42
+ARG AZURE_CLI_VERSION=2.30
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Amido Stacks <stacks@amido.com>"
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
@@ -90,8 +91,8 @@ RUN apt-get install -y \
     gnupg-agent \
     software-properties-common
 
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 RUN apt-get update -y && \
     apt-get install -y docker-ce-cli

--- a/libs/images/tf-deploy/Dockerfile
+++ b/libs/images/tf-deploy/Dockerfile
@@ -1,6 +1,7 @@
-FROM debian:11-slim
+FROM ubuntu:20.04
 
-ARG TF_VERSION=0.13.7
+ARG TF_VERSION=1.0.11
+ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Amido Stacks <stacks@amido.com>"
 


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Update k8s-deploy image to use ubuntu as a base image rather than debian

<!--
If you have access, to ink to the Azure DevOps Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
Reduce security vulnerabilities
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
