### PR TITLE
chore: bump node14 to newer base image

### DIFF
--- a/libs/images/node-14/Dockerfile
+++ b/libs/images/node-14/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:14.17.3-buster-slim
+FROM node:14.18-bullseye-slim
 
-ARG NODE_VERSION=12.x
+ARG NODE_VERSION=14.x
 ARG TYPESCRIPT_VERSION=3.7.5
 
 LABEL maintainer="Amido Stacks <stacks@amido.com>"


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

A description of the change.

<!--
If you have access, to ink to the Azure DevOps Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
Move node14 image to a newer base os (debian 11)
		
#### 🛠 How
		
Use `14.18-bullseye-slim` as from image

#### 👀 Evidence

Image builds successfully:
		
```PS C:\repos\github\amido\stacks\stacks-webapp-template\libs\images\node-14> docker build . -t amidostacks/node-14
[+] Building 3.3s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 32B                                                                                                                                                                                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/node:14.18-bullseye-slim                                                                                                                                                                                                                                            3.2s
 => [1/4] FROM docker.io/library/node:14.18-bullseye-slim@sha256:3e8d45e2d29edd28b7789040a418b519f94adfd97076458674004b4a8cc0482f                                                                                                                                                                                      0.0s
 => CACHED [2/4] RUN apt-get update -y &&     apt-get upgrade -y &&     apt-get install -y curl grep sed unzip &&     apt-get clean                                                                                                                                                                                    0.0s
 => CACHED [3/4] RUN npm install -g typescript@3.7.5 @types/node                                                                                                                                                                                                                                                       0.0s
 => CACHED [4/4] RUN chmod -R 777 /usr/local/lib/node_modules                                                                                                                                                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                0.0s
 => => writing image sha256:8cd1e0fd052ebe7adff870c71294cc71b69b05585ae3f21d3a98613d1ed36dd4                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/amidostacks/node-14                                                                                                                                                                                                                                                                         0.0s
PS C:\repos\github\amido\stacks\stacks-webapp-template\libs\images\node-14> 
```
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
