### PR TITLE
chore: remove unused dockerfile

### DIFF
--- a/libs/images/azul-java-chromium/Dockerfile
+++ b/libs/images/azul-java-chromium/Dockerfile
@@ -1,9 +1,0 @@
-FROM azul/zulu-openjdk-debian:11.0.12
-
-RUN apt-get update \
-  && apt-get install -y chromium wget unzip \
-  && apt-get clean -y \
-  && wget https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip \
-  && unzip chromedriver_linux64.zip \
-  && mv chromedriver /usr/local/bin \
-  && rm chromedriver_linux64.zip


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Remove `azul-java-chromium` Dockerfile 

<!--
If you have access, to ink to the Azure DevOps Ticket use `AB#{ID}`, eg. Implements `[AB#1228](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/1228) - Link tickets to GitHub`
-->

#### 🤔 Why
		
It is no longer used - there are no active references to it in the current stacks-java implementations.
		
#### 🛠 How
		
Removed dockerfile

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
